### PR TITLE
better-approach by using custom flow layout

### DIFF
--- a/PeekCollectionView.xcodeproj/project.pbxproj
+++ b/PeekCollectionView.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		AFBB32ED22DE3A5100EA7BCD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AFBB32EC22DE3A5100EA7BCD /* Assets.xcassets */; };
 		AFBB32F022DE3A5100EA7BCD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AFBB32EE22DE3A5100EA7BCD /* LaunchScreen.storyboard */; };
 		AFBB32F922DF22EB00EA7BCD /* PeekCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBB32F722DF22EB00EA7BCD /* PeekCollectionViewCell.swift */; };
+		E20437DA22E525DC0074F86C /* SnappingCollectionViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20437D922E525DC0074F86C /* SnappingCollectionViewLayout.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +25,7 @@
 		AFBB32EF22DE3A5100EA7BCD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		AFBB32F122DE3A5100EA7BCD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AFBB32F722DF22EB00EA7BCD /* PeekCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeekCollectionViewCell.swift; sourceTree = "<group>"; };
+		E20437D922E525DC0074F86C /* SnappingCollectionViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnappingCollectionViewLayout.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +61,7 @@
 				AFBB32E522DE3A4F00EA7BCD /* AppDelegate.swift */,
 				AFBB32F722DF22EB00EA7BCD /* PeekCollectionViewCell.swift */,
 				AFBB32E722DE3A4F00EA7BCD /* PeekViewController.swift */,
+				E20437D922E525DC0074F86C /* SnappingCollectionViewLayout.swift */,
 				AFBB32E922DE3A4F00EA7BCD /* Main.storyboard */,
 				AFBB32EC22DE3A5100EA7BCD /* Assets.xcassets */,
 				AFBB32EE22DE3A5100EA7BCD /* LaunchScreen.storyboard */,
@@ -140,6 +143,7 @@
 			files = (
 				AFBB32E822DE3A4F00EA7BCD /* PeekViewController.swift in Sources */,
 				AFBB32E622DE3A4F00EA7BCD /* AppDelegate.swift in Sources */,
+				E20437DA22E525DC0074F86C /* SnappingCollectionViewLayout.swift in Sources */,
 				AFBB32F922DF22EB00EA7BCD /* PeekCollectionViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PeekCollectionView/Base.lproj/Main.storyboard
+++ b/PeekCollectionView/Base.lproj/Main.storyboard
@@ -21,15 +21,10 @@
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="6PK-Mo-bd5">
                                 <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="HNG-cD-CZc">
-                                    <size key="itemSize" width="354" height="532"/>
-                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                </collectionViewFlowLayout>
+                                <collectionViewLayout key="collectionViewLayout" id="XLZ-wZ-Obm" customClass="SnappingCollectionViewLayout" customModule="PeekCollectionView" customModuleProvider="target"/>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="PeekCollectionViewCell" id="Kq5-do-xDJ" customClass="PeekCollectionViewCell" customModule="PeekCollectionView" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="121" width="354" height="532"/>
+                                        <rect key="frame" x="30" y="0.0" width="354" height="532"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
                                             <rect key="frame" x="0.0" y="0.0" width="354" height="532"/>

--- a/PeekCollectionView/SnappingCollectionViewLayout.swift
+++ b/PeekCollectionView/SnappingCollectionViewLayout.swift
@@ -1,0 +1,50 @@
+//
+//  SnappingCollectionViewLayout.swift
+//  PeekCollectionView
+//
+//  Created by Ahmed Elzohry on 7/22/19.
+//  Copyright © 2019 Abdelrahman Mohamed. All rights reserved.
+//
+
+import UIKit
+
+/* check
+    https://stackoverflow.com/questions/33855945/uicollectionview-snap-onto-cell-when-scrolling-horizontally
+    https://developer.apple.com/documentation/uikit/uicollectionviewlayout/1617729-targetcontentoffset
+ */
+class SnappingCollectionViewLayout: UICollectionViewFlowLayout {
+    
+    override init() {
+        super.init()
+        
+        scrollDirection = .horizontal
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        
+        scrollDirection = .horizontal
+    }
+    
+    override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint, withScrollingVelocity velocity: CGPoint) -> CGPoint {
+        guard let collectionView = collectionView else {
+            return super.targetContentOffset(forProposedContentOffset: proposedContentOffset, withScrollingVelocity: velocity)
+        }
+        
+        var offsetAdjustment = CGFloat.greatestFiniteMagnitude
+        let horizontalOffset = proposedContentOffset.x + collectionView.contentInset.left
+        
+        let targetRect = CGRect(x: proposedContentOffset.x, y: 0, width: collectionView.bounds.size.width, height: collectionView.bounds.size.height)
+        
+        let layoutAttributesArray = super.layoutAttributesForElements(in: targetRect)
+        
+        layoutAttributesArray?.forEach({ (layoutAttributes) in
+            let itemOffset = layoutAttributes.frame.origin.x
+            if fabsf(Float(itemOffset - horizontalOffset)) < fabsf(Float(offsetAdjustment)) {
+                offsetAdjustment = itemOffset - horizontalOffset
+            }
+        })
+        
+        return CGPoint(x: proposedContentOffset.x + offsetAdjustment, y: proposedContentOffset.y)
+    }
+}


### PR DESCRIPTION
check:
[https://stackoverflow.com/questions/33855945/uicollectionview-snap-onto-cell-when-scrolling-horizontally](https://stackoverflow.com/questions/33855945/uicollectionview-snap-onto-cell-when-scrolling-horizontally)
[https://developer.apple.com/documentation/uikit/uicollectionviewlayout/1617729-targetcontentoffset](https://developer.apple.com/documentation/uikit/uicollectionviewlayout/1617729-targetcontentoffset)

Side note: you don't need to conform to both UICollectionViewDelegateFlowLayout and UICollectionViewDelegate because UICollectionViewDelegateFlowLayout already inherits UICollectionViewDelegate